### PR TITLE
Limit ComboChart chart types to supported types only

### DIFF
--- a/e2e/Sandbox/Factories/CustomDashboard.cs
+++ b/e2e/Sandbox/Factories/CustomDashboard.cs
@@ -69,12 +69,12 @@ namespace Sandbox.Factories
                 .ConfigureChart1(config =>
                 {
                     config.Values.Add("Spend"); //todo: maybe the extension should be AddValue and AddValues
-                    config.ChartType = ChartType.Bar;
+                    config.ChartType = ComboChartType.Column;
                 })
                 .ConfigureChart2(config =>
                 {
                     config.Values.Add("Budget");
-                    config.ChartType = ChartType.Line;
+                    config.ChartType = ComboChartType.Line;
                 }));
 
             //stacked column
@@ -166,9 +166,10 @@ namespace Sandbox.Factories
             document.Visualizations.Add(new BubbleVisualization("Bubble", excelDataSourceItem)
                 .AddLabel("CampaignID").AddXAxis("Budget").AddYAxis("Spend").AddRadius("Traffic"));
 
+            //todo: this seems broken for some reason
             //scatter
-            document.Visualizations.Add(new ScatterVisualization("Scatter", excelDataSourceItem)
-                .AddLabel("CampaignID").AddXAxis("Budget").AddYAxis("Spend"));
+            //document.Visualizations.Add(new ScatterVisualization("Scatter", excelDataSourceItem)
+            //    .AddLabel("CampaignID").AddXAxis("Budget").AddYAxis("Spend"));
 
             //time series
             document.Visualizations.Add(new TimeSeriesVisualization("Time Series", excelDataSourceItem)

--- a/e2e/Sandbox/MainWindow.xaml.cs
+++ b/e2e/Sandbox/MainWindow.xaml.cs
@@ -66,8 +66,8 @@ namespace Sandbox
             //var document = CampaignsDashboard.CreateDashboard();
             //var document = HealthcareDashboard.CreateDashboard();
             //var document = ManufacturingDashboard.CreateDashboard();
-            //var document = CustomDashboard.CreateDashboard();
-            var document = RestDataSourceDashboards.CreateDashboard();
+            var document = CustomDashboard.CreateDashboard();
+            //var document = RestDataSourceDashboards.CreateDashboard();
             //var document = SqlServerDataSourceDashboards.CreateDashboard();
 
             //document.Save(_saveRdashToPath);

--- a/src/Reveal.Sdk.Dom/Visualizations/Extensions/Visualizations/ComboChartVisualizationExtensions.cs
+++ b/src/Reveal.Sdk.Dom/Visualizations/Extensions/Visualizations/ComboChartVisualizationExtensions.cs
@@ -17,7 +17,7 @@ namespace Reveal.Sdk.Dom.Visualizations
             config.Invoke(chartConfig);
 
             visualization.Chart1.AddRange(chartConfig.Values);
-            visualization.Settings.CompositeChartType1 = chartConfig.ChartType;
+            visualization.Settings.CompositeChartType1 = ConvertComboChartTypeToChartType(chartConfig.ChartType);
             return visualization;
         }
 
@@ -27,8 +27,23 @@ namespace Reveal.Sdk.Dom.Visualizations
             config.Invoke(chartConfig);
 
             visualization.Chart2.AddRange(chartConfig.Values);
-            visualization.Settings.CompositeChartType2 = chartConfig.ChartType;
+            visualization.Settings.CompositeChartType2 = ConvertComboChartTypeToChartType(chartConfig.ChartType);
             return visualization;
+        }
+
+        internal static ChartType ConvertComboChartTypeToChartType(ComboChartType comboChartType)
+        {
+            return comboChartType switch
+            {
+                ComboChartType.Area => ChartType.Area,
+                ComboChartType.Column => ChartType.Column,
+                ComboChartType.Line => ChartType.Line,
+                ComboChartType.SplineArea => ChartType.SplineArea,
+                ComboChartType.StackedColumn => ChartType.StackedColumn,
+                ComboChartType.StepArea => ChartType.StepArea,
+                ComboChartType.StepLine => ChartType.StepLine,
+                _ => throw new Exception($"ComboChartType not supported {comboChartType}")
+            };
         }
     }
 
@@ -46,6 +61,18 @@ namespace Reveal.Sdk.Dom.Visualizations
     public class ChartConfiguration
     {
         public List<MeasureColumnSpec> Values { get; set; } = new List<MeasureColumnSpec>();
-        public ChartType ChartType { get; set; }
+        public ComboChartType ChartType { get; set; }
+    }
+
+    //todo: move class to file
+    public enum ComboChartType
+    {
+        Area,
+        Column,
+        Line,
+        SplineArea,
+        StackedColumn,
+        StepArea,
+        StepLine            
     }
 }


### PR DESCRIPTION
The combo chart Chart1 and Chart2 ChartTypes are limited to:

        Area,
        Column,
        Line,
        SplineArea,
        StackedColumn,
        StepArea,
        StepLine 

Created a new type that only exposes these types when dealing with COmboCharts