### PR TITLE
Update JoinTable logic

### DIFF
--- a/src/Reveal.Sdk.Dom.Tests/Core/Utilities/RdashDocumentValidatorFixture.cs
+++ b/src/Reveal.Sdk.Dom.Tests/Core/Utilities/RdashDocumentValidatorFixture.cs
@@ -151,7 +151,7 @@ namespace Reveal.Sdk.Dom.Tests.Core.Utilities
         }
 
         [Fact]
-        public void Validate_JoinTables_JoinsAreNotDuplicated()
+        public void Validate_PreventsDuplicates_OnMultipleValidations()
         {
             var dataSourceItem = new DataSourceItem("Test", new DataSource()).SetFields(new List<IField> { new TextField() });
             var joinConditions = new List<JoinCondition> { new JoinCondition("left", "right") };

--- a/src/Reveal.Sdk.Dom.Tests/Data/DataSourceItemFixture.cs
+++ b/src/Reveal.Sdk.Dom.Tests/Data/DataSourceItemFixture.cs
@@ -92,7 +92,7 @@ namespace Reveal.Sdk.Dom.Tests.Data
         }
 
         [Fact]
-        public void DataSourceItem_Join_AddsJoinTable()
+        public void DataSourceItem_Join_AddsJoinTableUsingJoinConditions()
         {
             // Arrange
             var dataSourceItem = new DataSourceItem();
@@ -101,6 +101,26 @@ namespace Reveal.Sdk.Dom.Tests.Data
 
             // Act
             dataSourceItem.Join("Alias", joinConditions, dataSourceItemToJoin);
+
+            // Assert
+            Assert.Single(dataSourceItem.JoinTables);
+            Assert.Equal("Alias", dataSourceItem.JoinTables[0].Alias);
+            Assert.Equal(dataSourceItemToJoin, dataSourceItem.JoinTables[0].DataDefinition.DataSourceItem);
+            Assert.Single(dataSourceItem.JoinTables[0].JoinConditions);
+            Assert.Equal("[left]", dataSourceItem.JoinTables[0].JoinConditions[0].LeftFieldName);
+            Assert.Equal("Alias.[right]", dataSourceItem.JoinTables[0].JoinConditions[0].RightFieldName);
+        }
+
+        [Fact]
+        public void DataSourceItem_Join_AddsJoinTableUsingLeftAndRightFieldNames()
+        {
+            // Arrange
+            var dataSourceItem = new DataSourceItem();
+            var joinConditions = new List<JoinCondition> { new JoinCondition("left", "right") };
+            var dataSourceItemToJoin = new DataSourceItem();
+
+            // Act
+            dataSourceItem.Join("Alias", "left", "right", dataSourceItemToJoin);
 
             // Assert
             Assert.Single(dataSourceItem.JoinTables);

--- a/src/Reveal.Sdk.Dom/Core/Utilities/RdashDocumentValidator.cs
+++ b/src/Reveal.Sdk.Dom/Core/Utilities/RdashDocumentValidator.cs
@@ -49,9 +49,11 @@ namespace Reveal.Sdk.Dom.Core.Utilities
 
         static void FixJoinedTables(TabularDataDefinition tdd)
         {
-            if (tdd.DataSourceItem.JoinTables != null)
+             // Check if there are duplicates
+            var hasDuplicates = tdd.JoinTables.GroupBy(jt => jt.Alias).Any(g => g.Count() > 1);
+            if (hasDuplicates)
             {
-                tdd.JoinTables.AddRange(tdd.DataSourceItem.JoinTables.Clone());
+                tdd.JoinTables = tdd.JoinTables.GroupBy(jt => jt.Alias).Select(g => g.First()).ToList();
             }
         }
 

--- a/src/Reveal.Sdk.Dom/Visualizations/Visualization.cs
+++ b/src/Reveal.Sdk.Dom/Visualizations/Visualization.cs
@@ -107,9 +107,9 @@ namespace Reveal.Sdk.Dom.Visualizations
             {
                 tdd.Fields = dataSourceItem.Fields.Clone();
                 
-                if(tdd.DataSourceItem.JoinTables != null)
+                if(tdd.DataSourceItem.JoinTables != null && tdd.DataSourceItem.JoinTables.Count > 0)
                 {
-                    tdd.JoinTables.AddRange(tdd.DataSourceItem.JoinTables.Clone());
+                    tdd.JoinTables = tdd.DataSourceItem.JoinTables.Clone();
                 }
             }
         }

--- a/src/Reveal.Sdk.Dom/Visualizations/Visualization.cs
+++ b/src/Reveal.Sdk.Dom/Visualizations/Visualization.cs
@@ -106,6 +106,11 @@ namespace Reveal.Sdk.Dom.Visualizations
             if (DataDefinition is TabularDataDefinition tdd)
             {
                 tdd.Fields = dataSourceItem.Fields.Clone();
+                
+                if(tdd.DataSourceItem.JoinTables != null)
+                {
+                    tdd.JoinTables.AddRange(tdd.DataSourceItem.JoinTables.Clone());
+                }
             }
         }
 


### PR DESCRIPTION
Moved JoinTables collection copy from the Validator to the Visualization.UpdateDataSourceItem
Mirrored fields logic to remove JoinTable duplicates during validation
Removed Validate_Adds_JoinTables test, replaced it with two new validator tests