### PR TITLE
Warn instead of throw on ValidateManuallyAddedDataSourceItem 

### DIFF
--- a/src/Reveal.Sdk.Dom.Tests/Core/Utilities/RdashDocumentValidatorFixture.cs
+++ b/src/Reveal.Sdk.Dom.Tests/Core/Utilities/RdashDocumentValidatorFixture.cs
@@ -256,7 +256,7 @@ namespace Reveal.Sdk.Dom.Tests.Core.Utilities
 
                 Trace.Listeners.Remove(listener);
 
-                Assert.Equal("warn: Warning: Data source with id TEST not found in the RdashDocument.DataSources collection.\r\n", listener.GetOutput());
+                Assert.Equal("warn: Warning: Data source with id TEST not found in the RdashDocument.DataSources collection.", listener.GetOutput().Replace("\r","").Replace("\n", "")); //replace line endings to make the test work on either Windows and Linux
             }
         }
 

--- a/src/Reveal.Sdk.Dom.Tests/Core/Utilities/RdashDocumentValidatorFixture.cs
+++ b/src/Reveal.Sdk.Dom.Tests/Core/Utilities/RdashDocumentValidatorFixture.cs
@@ -3,6 +3,8 @@ using Reveal.Sdk.Dom.Data;
 using Reveal.Sdk.Dom.Visualizations;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
 using System.Linq;
 using Xunit;
 
@@ -10,6 +12,35 @@ namespace Reveal.Sdk.Dom.Tests.Core.Utilities
 {
     public class RdashDocumentValidatorFixture
     {
+        private class DebugOutputListener : TraceListener
+        {
+            private readonly StringWriter _stringWriter = new StringWriter();
+
+            public override void Write(string message)
+            {
+                _stringWriter.Write(message);
+            }
+
+            public override void WriteLine(string message)
+            {
+                _stringWriter.WriteLine(message);
+            }
+
+            public string GetOutput()
+            {
+                return _stringWriter.ToString();
+            }
+
+            protected override void Dispose(bool disposing)
+            {
+                if (disposing)
+                {
+                    _stringWriter.Dispose();
+                }
+                base.Dispose(disposing);
+            }
+        }
+
         [Fact]
         public void Validate_AddsDataSources_ToRdashDocument()
         {
@@ -204,7 +235,7 @@ namespace Reveal.Sdk.Dom.Tests.Core.Utilities
         }
 
         [Fact]
-        public void Validate_ThrowsException_WhenDataSourceItem_WithDataSourceId_CantFindDataSource()
+        public void Validate_Warns_WhenDataSourceItem_WithDataSourceId_CantFindDataSource()
         {
             // Arrange
             var dataSourceItem = new DataSourceItem() { DataSourceId = "TEST", Fields = new List<IField>() { new TextField() } };
@@ -216,7 +247,17 @@ namespace Reveal.Sdk.Dom.Tests.Core.Utilities
             document.Visualizations.Add(viz);
 
             // Act & Assert
-            Assert.Throws<Exception>(() => RdashDocumentValidator.Validate(document));
+
+            using (var listener = new DebugOutputListener())
+            {
+                Trace.Listeners.Add(listener);
+
+                RdashDocumentValidator.Validate(document);
+
+                Trace.Listeners.Remove(listener);
+
+                Assert.Equal("warn: Warning: Data source with id TEST not found in the RdashDocument.DataSources collection.\r\n", listener.GetOutput());
+            }
         }
 
         [Fact]

--- a/src/Reveal.Sdk.Dom/Core/Utilities/RdashDocumentValidator.cs
+++ b/src/Reveal.Sdk.Dom/Core/Utilities/RdashDocumentValidator.cs
@@ -3,6 +3,7 @@ using Reveal.Sdk.Dom.Filters;
 using Reveal.Sdk.Dom.Visualizations;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 
 namespace Reveal.Sdk.Dom.Core.Utilities
@@ -79,13 +80,13 @@ namespace Reveal.Sdk.Dom.Core.Utilities
         {
             var ds = document.DataSources?.FirstOrDefault(x => x.Id == dsi.DataSourceId);
             if (ds == null)
-                throw new Exception($"Data source with id {dsi.DataSourceId} not found in the RdashDocument.DataSources collection.");
+                Debug.WriteLine($"Warning: Data source with id {dsi.DataSourceId} not found in the RdashDocument.DataSources collection.","warn");
 
             if (dsi.ResourceItem != null)
             {
                 var rds = document.DataSources?.FirstOrDefault(x => x.Id == dsi.ResourceItem.DataSourceId);
                 if (rds == null)
-                    throw new Exception($"ResourceItem with Data source id {dsi.ResourceItem.DataSourceId} not found in the RdashDocument.DataSources collection.");
+                Debug.WriteLine($"Warning: ResourceItem with Data source id {dsi.ResourceItem.DataSourceId} not found in the RdashDocument.DataSources collection.", "warn");
             }
         }
 


### PR DESCRIPTION
Change the exception thrown on ValidateManuallyAddedDataSourceItem to a warning, as some special datasources (e.g.: '__EXCEL'), would erroneously trigger the exception.